### PR TITLE
Change versioning reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,12 @@ Principles of a change log, excerpted from [Keep a Changelog](http://keepachange
 ### Added
  * Code of Conduct from [Contributor Covenant v1.4.1](https://www.contributor-covenant.org/).
  * [License](LICENSE.md).
- * Git metafiles and ReadMe file.
+ * Git metafiles (`.gitignore` and `.gitattributes`).
+ * GitHub templates:
+   - Issues;
+   - Feature request;
+   - User question;
+   - Pull request.
+ * ReadMe file.
  * Changelog file.
+ * ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before sending your pull requests, make sure you followed this list.
 
 1. Read [contributing guidelines](CONTRIBUTING.md).
 2. Read [Code of Conduct](CODE-OF-CONDUCT.md).
-3. Increase the version numbers in any examples files and the [package.json](package.json) to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+3. Increase the version numbers in any examples files and the {{PKG_VERS}} to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
 4. You may merge the Pull Request in once you have the approval of the project owner.
 
 ## Reporting a Bug & Requesting Features

--- a/DELETE_ME.md
+++ b/DELETE_ME.md
@@ -11,7 +11,9 @@ This repo's template features the minimal barebones needed for a general [git](h
 * Contributing guidelines;
 * [MIT License](https://opensource.org/licenses/MIT);
 * Read Me file;
-* GitHub's issue and feature request templates;
+* GitHub templates:
+  - Issue and feature request templates;
+  - Pull request templates;
 * GitHub Bots' configuration.
 
 ## Bots
@@ -51,7 +53,9 @@ In order to make this repository your own, follow these steps:
   - [ ] Search folder for `{{PKG_NAME}}` and replace all instaces by the repository name;
   - [ ] Search folder for `{{PKG_REPO}}` and replace all instaces by the repository's author and name as the format `author/package-name` (*e.g.* `Nereare/pretty-regret`); and
   - [ ] Search folder for `{{PKG_YEAR}}` and replace all instaces by the repository copyright years with four digits (*e.g.* `2019` or `2012-2018`);
-- [ ] On the [Read Me file](README.md), delete the line referring to this tutorial.
+  - [ ] Search folder for `{{PKG_VERS}}` and replace all instaces by the file or files used to keep versioning, preferably as a link (*e.g.* `[package.json](package.json)`);
+- [ ] On the [ReadMe file](README.md), check the version badge, which uses a `package.json` file to fetch the version, if this is not the method for this repository, change it accordingly;
+- [ ] On the [ReadMe file](README.md), delete the line referring to this tutorial.
 
 Now you are all set! :tada:
 

--- a/DELETE_ME.md
+++ b/DELETE_ME.md
@@ -2,7 +2,7 @@
 
 Hello and welcome!
 
-This repo's template features the minimal barebones needed for a general [git]() project to feature:
+This repo's template features the minimal barebones needed for a general [git](https://git-scm.com/) project to feature:
 
 * Git attributes file;
 * Git ignore file;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # {{PKG_NAME}}
 
+<!--
+TODO Change version reference badge
+BODY The [ReadMe file](README.md) has a badge referring to the repository's version. By default we use [Shields](https://shields.io/)' JSON version badge. If you are using a file other than a `.json` to keep version, change the line below.
+-->
 [![GitHub package.json version](https://img.shields.io/github/package-json/v/{{PKG_REPO}})](https://github.com/{{PKG_REPO}})
 [![License](https://img.shields.io/github/license/{{PKG_REPO}}.svg)](https://github.com/{{PKG_REPO}})
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE-OF-CONDUCT.md)


### PR DESCRIPTION
Change the default reference, on the [contrubuting guidelines](CONTRIBUTING.md), to the file which keeps the version of the repository, to be changed on the configuration of the newly created repository.

- **Changed:**
  - Reference to the versioning file.